### PR TITLE
chore: disable pip locking

### DIFF
--- a/bentofile.yaml
+++ b/bentofile.yaml
@@ -7,3 +7,4 @@ include:
 - "bentovllm_openai/*.py"
 python:
   requirements_txt: "./requirements.txt"
+  lock_packages: false


### PR DESCRIPTION
So user without cuda device can still deploy this repository