### PR TITLE
Fix: llama3 bento deployment configuration

### DIFF
--- a/llama3-70b-instruct-awq/bentofile.yaml
+++ b/llama3-70b-instruct-awq/bentofile.yaml
@@ -5,12 +5,8 @@ labels:
 include:
   - '*.py'
   - 'bentovllm_openai/*.py'
-  - 'setup.sh'
 python:
   requirements_txt: './requirements.txt'
   lock_packages: false
 docker:
   python_version: 3.11
-  setup_script: './setup.sh'
-  system_packages:
-    - git

--- a/llama3-70b-instruct-awq/setup.sh
+++ b/llama3-70b-instruct-awq/setup.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE pip3 install flash-attn==2.5.7 --no-build-isolation

--- a/llama3-8b-instruct/bentofile.yaml
+++ b/llama3-8b-instruct/bentofile.yaml
@@ -5,7 +5,6 @@ labels:
 include:
   - '*.py'
   - 'bentovllm_openai/*.py'
-  - 'setup.sh'
 python:
   requirements_txt: './requirements.txt'
   lock_packages: false
@@ -13,6 +12,3 @@ envs:
   - name: HF_TOKEN
 docker:
   python_version: 3.11
-  setup_script: './setup.sh'
-  system_packages:
-    - git

--- a/llama3-8b-instruct/setup.sh
+++ b/llama3-8b-instruct/setup.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE pip3 install flash-attn==2.5.7 --no-build-isolation


### PR DESCRIPTION
For vllm 0.4.3, the flash attention functionality is automatically provided by `vllm-flash-attn`, we don't need use our own `setup.sh` to install this package.